### PR TITLE
Modernize packaging

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,7 +108,7 @@ Please raise an issue if you have problems.
 Dependencies
 ============
 
-- Python >3.5
+- Python >=3.8
 - If you run the examples option you will need many more tools. See
   the Dockerfiles included for specific instructions.
 

--- a/project_quickstart/__init__.py
+++ b/project_quickstart/__init__.py
@@ -1,9 +1,7 @@
-# Python 2 to 3 changed the use of __init__.py
-# To avoid namespace problems use this for 2 and 3 compatibility
-# https://packaging.python.org/namespace_packages/?highlight=__init__
-# Otherwise omit __init__.py entirely unless you have sub-packages
+"""project_quickstart package."""
 
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)
+from .version import set_version
 
-# from .project_quickstart import project_quickstart
-# from .project_quickstart import projectQuickstart
+__all__ = ["__version__"]
+
+__version__ = set_version()

--- a/project_quickstart/version.py
+++ b/project_quickstart/version.py
@@ -1,3 +1,5 @@
 def set_version():
-    __version__ = '0.3.7'
-    return(__version__)
+    """Return the current package version."""
+
+    __version__ = "0.3.8"
+    return __version__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "project_quickstart"
+version = "0.3.8"
+description = "Boilerplate tools and templates for setting up a data analysis project."
+readme = "README.rst"
+requires-python = ">=3.8"
+dependencies = ["docopt"]
+license = {file = "LICENSE"}
+


### PR DESCRIPTION
## Summary
- modernize packaging with a `pyproject.toml`
- bump the package version to 0.3.8
- remove old Python 2 compatibility code in `__init__.py`
- document Python 3.8+ requirement

## Testing
- `pytest -q` *(fails: project_quickstart pipeline template missing)*

------
https://chatgpt.com/codex/tasks/task_e_688a89fe01c4832693721c6b806d0b36