### PR TITLE
Update tests to use new CLI functions

### DIFF
--- a/project_quickstart/project_quickstart.py
+++ b/project_quickstart/project_quickstart.py
@@ -98,11 +98,17 @@ CONFIG = configparser.ConfigParser(allow_no_value = True)
 
 
 ##############################
-def main():
-    ''' with docopt main() expects a dictionary with arguments from docopt()
-    docopt will automatically check your docstrings for usage, set -h, etc.
-    '''
-    options = docopt.docopt(__doc__, version = version)
+def main(argv=None):
+    """Execute the command line interface.
+
+    Parameters
+    ----------
+    argv : list[str] or None, optional
+        Arguments to parse with :func:`docopt.docopt`.  When ``None`` the
+        arguments are taken from ``sys.argv`` (the default behaviour of
+        ``docopt``).
+    """
+    options = docopt.docopt(__doc__, argv=argv, version=version)
     welcome_msg = str('\n' + 'Welcome to project_quickstart version {} (!).'
                       + '\n').format(version)
     # print(welcome_msg)
@@ -623,6 +629,36 @@ def main():
                         )
 
     return
+
+
+def create_project(name, *, argv_prefix=None):
+    """Programmatically create a project skeleton."""
+    args = [f"--project-name={name}"]
+    return main(args if argv_prefix is None else argv_prefix + args)
+
+
+def create_python_script(name, *, argv_prefix=None):
+    """Create a standalone Python script template."""
+    args = [f"--script-python={name}"]
+    return main(args if argv_prefix is None else argv_prefix + args)
+
+
+def create_r_script(name, *, argv_prefix=None):
+    """Create a standalone R script template."""
+    args = [f"--script-R={name}"]
+    return main(args if argv_prefix is None else argv_prefix + args)
+
+
+def create_pipeline(name, *, argv_prefix=None):
+    """Create a pipeline template directory."""
+    args = [f"--script-pipeline={name}"]
+    return main(args if argv_prefix is None else argv_prefix + args)
+
+
+def create_example(*, argv_prefix=None):
+    """Generate the example project."""
+    args = ["--example"]
+    return main(args if argv_prefix is None else argv_prefix + args)
 
 
 if __name__ == '__main__':

--- a/project_quickstart/project_quickstart.py
+++ b/project_quickstart/project_quickstart.py
@@ -633,7 +633,7 @@ def main(argv=None):
 
 def create_project(name, *, argv_prefix=None):
     """Programmatically create a project skeleton."""
-    args = [f"--project-name={name}"]
+    args = [f"-n={name}"]
     return main(args if argv_prefix is None else argv_prefix + args)
 
 

--- a/tests/test_project_quickstart.py
+++ b/tests/test_project_quickstart.py
@@ -39,7 +39,6 @@ Options:
 # System:
 import pytest
 import os
-import sys
 
 # Import helper functions from this package:
 import pytest_helpers

--- a/tests/test_project_quickstart.py
+++ b/tests/test_project_quickstart.py
@@ -39,7 +39,6 @@ Options:
 # System:
 import pytest
 import os
-import tempfile
 import sys
 
 # Import helper functions from this package:
@@ -57,12 +56,21 @@ test_name = 'pq_test_ref'
 # For each dir generate and compare directory trees and compare ref and test files
 # For each script (py and R) compare ref and test files
 
-cli_options = [[sys.executable, '-m', 'project_quickstart.project_quickstart', '-n', '{}'.format(test_name)],
-               [sys.executable, '-m', 'project_quickstart.project_quickstart', '--script-python={}'.format(test_name)],
-               [sys.executable, '-m', 'project_quickstart.project_quickstart', '--script-R={}'.format(test_name)],
-               [sys.executable, '-m', 'project_quickstart.project_quickstart', '--script-pipeline={}'.format(test_name)],
-               [sys.executable, '-m', 'project_quickstart.project_quickstart', '--example'],
-               ]
+from project_quickstart.project_quickstart import (
+    create_project,
+    create_python_script,
+    create_r_script,
+    create_pipeline,
+    create_example,
+)
+
+cli_options = [
+    lambda: create_project('{}'.format(test_name)),
+    lambda: create_python_script('{}'.format(test_name)),
+    lambda: create_r_script('{}'.format(test_name)),
+    lambda: create_pipeline('{}'.format(test_name)),
+    create_example,
+]
 
 dirs = ['{}'.format(test_name),
         'pipeline_{}'.format(test_name),
@@ -82,10 +90,14 @@ dirs = ['{}'.format(test_name),
 ref_dir = os.path.abspath(os.path.join('tests', 'ref_files'))
 print(ref_dir)
 
-# Create temporary directory for test outputs:
-test_dir = tempfile.mkdtemp()
-print(test_dir)
-os.chdir(test_dir)
+
+@pytest.fixture(scope="module")
+def workspace(tmp_path_factory):
+    tmp_dir = tmp_path_factory.mktemp("pq_test")
+    cwd = os.getcwd()
+    os.chdir(tmp_dir)
+    yield str(tmp_dir)
+    os.chdir(cwd)
 #####
 
 
@@ -94,16 +106,17 @@ os.chdir(test_dir)
 # Run each project_quickstart CLI option:
 # Functions that are needed to create test files should use the pytest.fixture decorator
 @pytest.fixture
-def run_cmds():
+def run_cmds(workspace):
     '''
     Run command line options for project_quickstart
     '''
-    pytest_helpers.run_CLI_options(cli_options)
+    for fn in cli_options:
+        fn()
 
 
 # For each dir generate and compare directory tree files:
 @pytest.fixture
-def dir_trees():
+def dir_trees(workspace):
     '''
     Generate files with the directory trees for project_quickstart
     '''
@@ -122,14 +135,14 @@ def dir_trees():
 # Collect and compare for each dir from ref and test, this will include files
 # created with '--script-' options and files with tree dirs:
 @pytest.mark.skip(reason="Known issue: pipeline template files missing during CI")
-def test_collect_and_compare_all_files(run_cmds, dir_trees):
+def test_collect_and_compare_all_files(run_cmds, dir_trees, workspace):
     '''
     Run project_quickstart commands and files with directory tree for this test and
     compare outputs of test vs reference files. Checks number of files, names of files
     and content of each test vs ref pair.
     '''
     dirs.append('.')  # Add cwd after creating tree dirs else erros as different lengths
-    pytest_helpers.compare_ref_and_test_dirs(dirs, ref_dir, test_dir, suffix = '')
+    pytest_helpers.compare_ref_and_test_dirs(dirs, ref_dir, workspace, suffix = '')
 
 
 print('Tests finished')

--- a/tests/test_project_quickstart.py
+++ b/tests/test_project_quickstart.py
@@ -69,7 +69,7 @@ cli_options = [
     lambda: create_python_script('{}'.format(test_name)),
     lambda: create_r_script('{}'.format(test_name)),
     lambda: create_pipeline('{}'.format(test_name)),
-    create_example,
+    lambda: create_example,
 ]
 
 dirs = ['{}'.format(test_name),


### PR DESCRIPTION
## Summary
- refactor `main` to accept argv and expose helper APIs
- add wrappers to create project resources programmatically
- rewrite tests to call these functions directly and use pytest tmp dirs

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a9bd4caf48326a241417d2d3df41d