### PR TITLE
Fix project scripts duplication

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,6 @@ include-package-data = true
 [tool.setuptools.packages.find]
 include = ["project_quickstart"]
 
-[project.scripts]
-project_quickstart = "project_quickstart.project_quickstart:main"
 
 [tool.setuptools.dynamic]
 version = {attr = "project_quickstart.version.__version__"}


### PR DESCRIPTION
## Summary
- remove duplicate `[project.scripts]` section in `pyproject.toml` to avoid build errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aae0edafc8326875eea634d3223f4