### PR TITLE
Fix unsafe YAML load

### DIFF
--- a/templates/examples/pipeline_pq_example/pipeline_report/conf.py
+++ b/templates/examples/pipeline_pq_example/pipeline_report/conf.py
@@ -102,7 +102,7 @@ else:
         print('Values found in INI file:', '\n')
         with open(ini_file, 'r') as ymlfile:
             try:
-                CONFIG = yaml.load(ymlfile)
+                CONFIG = yaml.safe_load(ymlfile)
                 print(yaml.dump(CONFIG))
 
             except yaml.YAMLError as e:

--- a/templates/project_template/docs/conf.py
+++ b/templates/project_template/docs/conf.py
@@ -102,7 +102,7 @@ else:
         print('Values found in INI file:', '\n')
         with open(ini_file, 'r') as ymlfile:
             try:
-                CONFIG = yaml.load(ymlfile)
+                CONFIG = yaml.safe_load(ymlfile)
                 print(yaml.dump(CONFIG))
 
             except yaml.YAMLError as e:

--- a/templates/report_templates/conf.py
+++ b/templates/report_templates/conf.py
@@ -102,7 +102,7 @@ else:
         print('Values found in INI file:', '\n')
         with open(ini_file, 'r') as ymlfile:
             try:
-                CONFIG = yaml.load(ymlfile)
+                CONFIG = yaml.safe_load(ymlfile)
                 print(yaml.dump(CONFIG))
 
             except yaml.YAMLError as e:

--- a/templates/script_templates/pipeline_template/pipeline_report/conf.py
+++ b/templates/script_templates/pipeline_template/pipeline_report/conf.py
@@ -102,7 +102,7 @@ else:
         print('Values found in INI file:', '\n')
         with open(ini_file, 'r') as ymlfile:
             try:
-                CONFIG = yaml.load(ymlfile)
+                CONFIG = yaml.safe_load(ymlfile)
                 print(yaml.dump(CONFIG))
 
             except yaml.YAMLError as e:

--- a/tests/ref_files/pipeline_pq_test_ref/pipeline_report/conf.py
+++ b/tests/ref_files/pipeline_pq_test_ref/pipeline_report/conf.py
@@ -102,7 +102,7 @@ else:
         print('Values found in INI file:', '\n')
         with open(ini_file, 'r') as ymlfile:
             try:
-                CONFIG = yaml.load(ymlfile)
+                CONFIG = yaml.safe_load(ymlfile)
                 print(yaml.dump(CONFIG))
 
             except yaml.YAMLError as e:

--- a/tests/ref_files/pq_example/code/docs/conf.py
+++ b/tests/ref_files/pq_example/code/docs/conf.py
@@ -102,7 +102,7 @@ else:
         print('Values found in INI file:', '\n')
         with open(ini_file, 'r') as ymlfile:
             try:
-                CONFIG = yaml.load(ymlfile)
+                CONFIG = yaml.safe_load(ymlfile)
                 print(yaml.dump(CONFIG))
 
             except yaml.YAMLError as e:

--- a/tests/ref_files/pq_example/code/pq_example/pipeline_pq_example/pipeline_report/conf.py
+++ b/tests/ref_files/pq_example/code/pq_example/pipeline_pq_example/pipeline_report/conf.py
@@ -102,7 +102,7 @@ else:
         print('Values found in INI file:', '\n')
         with open(ini_file, 'r') as ymlfile:
             try:
-                CONFIG = yaml.load(ymlfile)
+                CONFIG = yaml.safe_load(ymlfile)
                 print(yaml.dump(CONFIG))
 
             except yaml.YAMLError as e:

--- a/tests/ref_files/pq_example/documents_and_manuscript/conf.py
+++ b/tests/ref_files/pq_example/documents_and_manuscript/conf.py
@@ -102,7 +102,7 @@ else:
         print('Values found in INI file:', '\n')
         with open(ini_file, 'r') as ymlfile:
             try:
-                CONFIG = yaml.load(ymlfile)
+                CONFIG = yaml.safe_load(ymlfile)
                 print(yaml.dump(CONFIG))
 
             except yaml.YAMLError as e:

--- a/tests/ref_files/pq_test_ref/code/docs/conf.py
+++ b/tests/ref_files/pq_test_ref/code/docs/conf.py
@@ -102,7 +102,7 @@ else:
         print('Values found in INI file:', '\n')
         with open(ini_file, 'r') as ymlfile:
             try:
-                CONFIG = yaml.load(ymlfile)
+                CONFIG = yaml.safe_load(ymlfile)
                 print(yaml.dump(CONFIG))
 
             except yaml.YAMLError as e:

--- a/tests/ref_files/pq_test_ref/code/pq_test_ref/pipeline_pq_test_ref/pipeline_report/conf.py
+++ b/tests/ref_files/pq_test_ref/code/pq_test_ref/pipeline_pq_test_ref/pipeline_report/conf.py
@@ -102,7 +102,7 @@ else:
         print('Values found in INI file:', '\n')
         with open(ini_file, 'r') as ymlfile:
             try:
-                CONFIG = yaml.load(ymlfile)
+                CONFIG = yaml.safe_load(ymlfile)
                 print(yaml.dump(CONFIG))
 
             except yaml.YAMLError as e:

--- a/tests/ref_files/pq_test_ref/documents_and_manuscript/conf.py
+++ b/tests/ref_files/pq_test_ref/documents_and_manuscript/conf.py
@@ -102,7 +102,7 @@ else:
         print('Values found in INI file:', '\n')
         with open(ini_file, 'r') as ymlfile:
             try:
-                CONFIG = yaml.load(ymlfile)
+                CONFIG = yaml.safe_load(ymlfile)
                 print(yaml.dump(CONFIG))
 
             except yaml.YAMLError as e:


### PR DESCRIPTION
## Summary
- use `yaml.safe_load` in configuration templates and test reference files

## Testing
- `flake8 .`
- `pytest -rP -v --cache-clear`

------
https://chatgpt.com/codex/tasks/task_e_688ab0c0784883269f3544fb2f1f3c93