### PR TITLE
Fix partial path process start

### DIFF
--- a/project_quickstart/project_quickstart.py
+++ b/project_quickstart/project_quickstart.py
@@ -624,7 +624,14 @@ def main(argv=None):
         if not pq_exec:
             raise FileNotFoundError('project_quickstart executable not found')
         subprocess.run([pq_exec, '-n', 'pq_example'], check=True)
-        shutil.rmtree('pq_example/code/pq_example', ignore_errors=True)
+        try:
+            shutil.rmtree('pq_example/code/pq_example')
+        except FileNotFoundError:
+            print("Directory 'pq_example/code/pq_example' not found. Skipping removal.")
+        except PermissionError:
+            print("Permission denied while removing 'pq_example/code/pq_example'.")
+        except Exception as e:
+            print(f"An unexpected error occurred while removing 'pq_example/code/pq_example': {e}")
         shutil.copytree(examples_dir,
                         os.path.abspath('pq_example/code/pq_example'),
                         ignore = shutil.ignore_patterns(*files_to_ignore)

--- a/project_quickstart/project_quickstart.py
+++ b/project_quickstart/project_quickstart.py
@@ -65,6 +65,7 @@ Documentation
 import sys
 import os
 import shutil
+import subprocess
 
 # Modules with Py2 to 3 conflicts:
 try:
@@ -619,8 +620,11 @@ def main(argv=None):
 
     # Finally, last options to run if specified:
     if options['--example'] and not options['--project-name']:
-        os.system('project_quickstart -n pq_example')
-        os.system('rm -rf pq_example/code/pq_example')
+        pq_exec = shutil.which('project_quickstart')
+        if not pq_exec:
+            raise FileNotFoundError('project_quickstart executable not found')
+        subprocess.run([pq_exec, '-n', 'pq_example'], check=True)
+        shutil.rmtree('pq_example/code/pq_example', ignore_errors=True)
         shutil.copytree(examples_dir,
                         os.path.abspath('pq_example/code/pq_example'),
                         ignore = shutil.ignore_patterns(*files_to_ignore)

--- a/templates/examples/plot_pq_example_mtcars.R
+++ b/templates/examples/plot_pq_example_mtcars.R
@@ -257,7 +257,7 @@ if (is.null(args[['--session']]) == FALSE) {
 # If using Rscript and creating plots, Rscript will create the file Rplots.pdf 
 # by default, it doesn't look like there is an easy way to suppress it, so deleting here:
 print('Deleting the file Rplots.pdf...')
-system('rm -f Rplots.pdf')
+if (file.exists('Rplots.pdf')) file.remove('Rplots.pdf')
 sessionInfo()
 print('Finished successfully')
 q()

--- a/templates/examples/plot_pq_example_pandas.R
+++ b/templates/examples/plot_pq_example_pandas.R
@@ -271,7 +271,7 @@ if (is.null(args[['--session']]) == FALSE) {
 # If using Rscript and creating plots, Rscript will create the file Rplots.pdf 
 # by default, it doesn't look like there is an easy way to suppress it, so deleting here:
 print('Deleting the file Rplots.pdf...')
-system('rm -f Rplots.pdf')
+if (file.exists('Rplots.pdf')) file.remove('Rplots.pdf')
 sessionInfo()
 print('Finished successfully')
 q()

--- a/templates/examples/pq_example.R
+++ b/templates/examples/pq_example.R
@@ -308,7 +308,7 @@ if (is.null(args[['--session']]) == FALSE) {
 # If using Rscript and creating plots, Rscript will create the file Rplots.pdf 
 # by default, it doesn't look like there is an easy way to suppress it, so deleting here:
 print('Deleting the file Rplots.pdf...')
-system('rm -f Rplots.pdf')
+if (file.exists('Rplots.pdf')) file.remove('Rplots.pdf')
 sessionInfo()
 print('Finished successfully.')
 q()

--- a/templates/examples/pq_example_mtcars.R
+++ b/templates/examples/pq_example_mtcars.R
@@ -186,7 +186,7 @@ if (is.null(args[['--session']]) == FALSE) {
 # If using Rscript and creating plots, Rscript will create the file Rplots.pdf 
 # by default, it doesn't look like there is an easy way to suppress it, so deleting here:
 print('Deleting the file Rplots.pdf...')
-system('rm -f Rplots.pdf')
+if (file.exists('Rplots.pdf')) file.remove('Rplots.pdf')
 sessionInfo()
 q()
 

--- a/templates/examples/svgutils_pq_example.py
+++ b/templates/examples/svgutils_pq_example.py
@@ -58,6 +58,8 @@ Documentation
 import os
 import sys
 import glob
+import shutil
+import subprocess
 
 # Options and help:
 import docopt
@@ -124,14 +126,18 @@ def plotSVG(plotA, plotB, outfile = 'F1_test'):
     #cairosvg.svg2pdf(url = layout_name_1,
     #                 write_to = layout_name_2
     #                 )
-    # Alternatively with inkscape:                                         
-    os.system('''inkscape --without-gui \
-                          --export-area-drawing \
-                          --export-margin=1 \
-                          --file={} \
-                          --export-pdf={}'''.format(layout_name_1,
-                                                    layout_name_2)
-                 )
+    # Alternatively with inkscape:
+    inkscape = shutil.which('inkscape')
+    if not inkscape:
+        raise FileNotFoundError('inkscape executable not found')
+    subprocess.run([
+        inkscape,
+        '--without-gui',
+        '--export-area-drawing',
+        '--export-margin=1',
+        f'--file={layout_name_1}',
+        f'--export-pdf={layout_name_2}',
+    ], check=True)
     #--export-dpi=300 \
     print('Saved file as pdf: {}'.format(layout_name_2))
 ##############

--- a/templates/script_templates/svgutils_template.py
+++ b/templates/script_templates/svgutils_template.py
@@ -77,6 +77,8 @@ Documentation
 import os
 import sys
 import glob
+import shutil
+import subprocess
 
 # Options and help:
 import docopt
@@ -195,13 +197,17 @@ def plotMultiSVG(plots_given, outfile, **kwargs):
         #                 )
 
         # Alternatively with inkscape:
-        os.system('''inkscape --without-gui \
-                              --export-area-drawing \
-                              --export-margin=2 \
-                              --file={} \
-                              --export-pdf={}'''.format(layout_name_1,
-                                                        layout_name_2)
-                 )
+        inkscape = shutil.which('inkscape')
+        if not inkscape:
+            raise FileNotFoundError('inkscape executable not found')
+        subprocess.run([
+            inkscape,
+            '--without-gui',
+            '--export-area-drawing',
+            '--export-margin=2',
+            f'--file={layout_name_1}',
+            f'--export-pdf={layout_name_2}',
+        ], check=True)
         # Inkscape has many more options, e.g. 
         # --export-background=white --export-dpi=300
         # See:

--- a/templates/script_templates/template.R
+++ b/templates/script_templates/template.R
@@ -421,7 +421,7 @@ if (!is.null(args[['--session']])) { # arg is NULL
 # If using Rscript and creating plots, Rscript will create the file Rplots.pdf
 # by default, it doesn't look like there is an easy way to suppress it, so deleting here:
 print('Deleting the file Rplots.pdf...')
-system('rm -f Rplots.pdf')
+if (file.exists('Rplots.pdf')) file.remove('Rplots.pdf')
 print('Finished successfully.')
 sessionInfo()
 q()

--- a/templates/script_templates/template_clean.R
+++ b/templates/script_templates/template_clean.R
@@ -227,7 +227,7 @@ if (!is.null(args[['--session']])) { # arg is NULL
 # If using Rscript and creating plots, Rscript will create the file Rplots.pdf
 # by default, it doesn't look like there is an easy way to suppress it, so deleting here:
 print('Deleting the file Rplots.pdf...')
-system('rm -f Rplots.pdf')
+if (file.exists('Rplots.pdf')) file.remove('Rplots.pdf')
 print('Finished successfully.')
 sessionInfo()
 q()

--- a/tests/helpers/pytest_helpers.py
+++ b/tests/helpers/pytest_helpers.py
@@ -28,6 +28,7 @@ for pytest to import this file as a module.
 import os
 import hashlib
 import subprocess
+import shutil
 import sys
 import difflib
 ##############
@@ -44,7 +45,11 @@ def run_CLI_options(options):
     '''
     for option in options:
         print('\n', 'Test message: ', 'Executing command: ', ' '.join(option))
-        subprocess.run(option, check = True)
+        cmd = option[0]
+        cmd_path = shutil.which(cmd)
+        if not cmd_path:
+            raise FileNotFoundError(f'{cmd} executable not found')
+        subprocess.run([cmd_path] + option[1:], check=True)
 
     return
 

--- a/tests/ref_files/pq_example/code/pq_example/plot_pq_example_mtcars.R
+++ b/tests/ref_files/pq_example/code/pq_example/plot_pq_example_mtcars.R
@@ -257,7 +257,7 @@ if (is.null(args[['--session']]) == FALSE) {
 # If using Rscript and creating plots, Rscript will create the file Rplots.pdf 
 # by default, it doesn't look like there is an easy way to suppress it, so deleting here:
 print('Deleting the file Rplots.pdf...')
-system('rm -f Rplots.pdf')
+if (file.exists('Rplots.pdf')) file.remove('Rplots.pdf')
 sessionInfo()
 print('Finished successfully')
 q()

--- a/tests/ref_files/pq_example/code/pq_example/plot_pq_example_pandas.R
+++ b/tests/ref_files/pq_example/code/pq_example/plot_pq_example_pandas.R
@@ -271,7 +271,7 @@ if (is.null(args[['--session']]) == FALSE) {
 # If using Rscript and creating plots, Rscript will create the file Rplots.pdf 
 # by default, it doesn't look like there is an easy way to suppress it, so deleting here:
 print('Deleting the file Rplots.pdf...')
-system('rm -f Rplots.pdf')
+if (file.exists('Rplots.pdf')) file.remove('Rplots.pdf')
 sessionInfo()
 print('Finished successfully')
 q()

--- a/tests/ref_files/pq_example/code/pq_example/pq_example.R
+++ b/tests/ref_files/pq_example/code/pq_example/pq_example.R
@@ -308,7 +308,7 @@ if (is.null(args[['--session']]) == FALSE) {
 # If using Rscript and creating plots, Rscript will create the file Rplots.pdf 
 # by default, it doesn't look like there is an easy way to suppress it, so deleting here:
 print('Deleting the file Rplots.pdf...')
-system('rm -f Rplots.pdf')
+if (file.exists('Rplots.pdf')) file.remove('Rplots.pdf')
 sessionInfo()
 print('Finished successfully.')
 q()

--- a/tests/ref_files/pq_example/code/pq_example/pq_example_mtcars.R
+++ b/tests/ref_files/pq_example/code/pq_example/pq_example_mtcars.R
@@ -186,7 +186,7 @@ if (is.null(args[['--session']]) == FALSE) {
 # If using Rscript and creating plots, Rscript will create the file Rplots.pdf 
 # by default, it doesn't look like there is an easy way to suppress it, so deleting here:
 print('Deleting the file Rplots.pdf...')
-system('rm -f Rplots.pdf')
+if (file.exists('Rplots.pdf')) file.remove('Rplots.pdf')
 sessionInfo()
 q()
 

--- a/tests/ref_files/pq_example/code/pq_example/svgutils_pq_example.py
+++ b/tests/ref_files/pq_example/code/pq_example/svgutils_pq_example.py
@@ -58,6 +58,8 @@ Documentation
 import os
 import sys
 import glob
+import shutil
+import subprocess
 
 # Options and help:
 import docopt
@@ -124,14 +126,18 @@ def plotSVG(plotA, plotB, outfile = 'F1_test'):
     #cairosvg.svg2pdf(url = layout_name_1,
     #                 write_to = layout_name_2
     #                 )
-    # Alternatively with inkscape:                                         
-    os.system('''inkscape --without-gui \
-                          --export-area-drawing \
-                          --export-margin=1 \
-                          --file={} \
-                          --export-pdf={}'''.format(layout_name_1,
-                                                    layout_name_2)
-                 )
+    # Alternatively with inkscape:
+    inkscape = shutil.which('inkscape')
+    if not inkscape:
+        raise FileNotFoundError('inkscape executable not found')
+    subprocess.run([
+        inkscape,
+        '--without-gui',
+        '--export-area-drawing',
+        '--export-margin=1',
+        f'--file={layout_name_1}',
+        f'--export-pdf={layout_name_2}',
+    ], check=True)
     #--export-dpi=300 \
     print('Saved file as pdf: {}'.format(layout_name_2))
 ##############

--- a/tests/ref_files/pq_test_ref.R
+++ b/tests/ref_files/pq_test_ref.R
@@ -421,7 +421,7 @@ if (!is.null(args[['--session']])) { # arg is NULL
 # If using Rscript and creating plots, Rscript will create the file Rplots.pdf
 # by default, it doesn't look like there is an easy way to suppress it, so deleting here:
 print('Deleting the file Rplots.pdf...')
-system('rm -f Rplots.pdf')
+if (file.exists('Rplots.pdf')) file.remove('Rplots.pdf')
 print('Finished successfully.')
 sessionInfo()
 q()

--- a/tests/ref_files/pq_test_ref/code/pq_test_ref/pq_test_ref.R
+++ b/tests/ref_files/pq_test_ref/code/pq_test_ref/pq_test_ref.R
@@ -421,7 +421,7 @@ if (!is.null(args[['--session']])) { # arg is NULL
 # If using Rscript and creating plots, Rscript will create the file Rplots.pdf
 # by default, it doesn't look like there is an easy way to suppress it, so deleting here:
 print('Deleting the file Rplots.pdf...')
-system('rm -f Rplots.pdf')
+if (file.exists('Rplots.pdf')) file.remove('Rplots.pdf')
 print('Finished successfully.')
 sessionInfo()
 q()

--- a/tests/ref_files/pq_test_ref/code/pq_test_ref/pq_test_ref_clean.R
+++ b/tests/ref_files/pq_test_ref/code/pq_test_ref/pq_test_ref_clean.R
@@ -227,7 +227,7 @@ if (!is.null(args[['--session']])) { # arg is NULL
 # If using Rscript and creating plots, Rscript will create the file Rplots.pdf
 # by default, it doesn't look like there is an easy way to suppress it, so deleting here:
 print('Deleting the file Rplots.pdf...')
-system('rm -f Rplots.pdf')
+if (file.exists('Rplots.pdf')) file.remove('Rplots.pdf')
 print('Finished successfully.')
 sessionInfo()
 q()

--- a/tests/ref_files/pq_test_ref/code/pq_test_ref/svgutils_pq_test_ref.py
+++ b/tests/ref_files/pq_test_ref/code/pq_test_ref/svgutils_pq_test_ref.py
@@ -77,6 +77,8 @@ Documentation
 import os
 import sys
 import glob
+import shutil
+import subprocess
 
 # Options and help:
 import docopt
@@ -195,13 +197,17 @@ def plotMultiSVG(plots_given, outfile, **kwargs):
         #                 )
 
         # Alternatively with inkscape:
-        os.system('''inkscape --without-gui \
-                              --export-area-drawing \
-                              --export-margin=2 \
-                              --file={} \
-                              --export-pdf={}'''.format(layout_name_1,
-                                                        layout_name_2)
-                 )
+        inkscape = shutil.which('inkscape')
+        if not inkscape:
+            raise FileNotFoundError('inkscape executable not found')
+        subprocess.run([
+            inkscape,
+            '--without-gui',
+            '--export-area-drawing',
+            '--export-margin=2',
+            f'--file={layout_name_1}',
+            f'--export-pdf={layout_name_2}',
+        ], check=True)
         # Inkscape has many more options, e.g. 
         # --export-background=white --export-dpi=300
         # See:


### PR DESCRIPTION
## Summary
- avoid starting processes with partial executable paths
- locate executables with `shutil.which`
- run `subprocess.run` instead of `os.system`
- remove `Rplots.pdf` via `file.remove()`

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ab08ef4a4832694897419520876e2