### PR TITLE
Fix tests and reference files

### DIFF
--- a/project_quickstart/project_quickstart.py
+++ b/project_quickstart/project_quickstart.py
@@ -641,25 +641,25 @@ def main(argv=None):
 
 def create_project(name, *, argv_prefix=None):
     """Programmatically create a project skeleton."""
-    args = [f"-n={name}"]
+    args = ["-n", name]
     return main(args if argv_prefix is None else argv_prefix + args)
 
 
 def create_python_script(name, *, argv_prefix=None):
     """Create a standalone Python script template."""
-    args = [f"--script-python={name}"]
+    args = ["--script-python", name]
     return main(args if argv_prefix is None else argv_prefix + args)
 
 
 def create_r_script(name, *, argv_prefix=None):
     """Create a standalone R script template."""
-    args = [f"--script-R={name}"]
+    args = ["--script-R", name]
     return main(args if argv_prefix is None else argv_prefix + args)
 
 
 def create_pipeline(name, *, argv_prefix=None):
     """Create a pipeline template directory."""
-    args = [f"--script-pipeline={name}"]
+    args = ["--script-pipeline", name]
     return main(args if argv_prefix is None else argv_prefix + args)
 
 

--- a/templates/script_templates/template_clean.R
+++ b/templates/script_templates/template_clean.R
@@ -113,7 +113,7 @@ LocationOfThisScript = function() # Function LocationOfThisScript returns the lo
         # But it may also be called from the command line
         cmd.args = commandArgs(trailingOnly = FALSE)
         cmd.args.trailing = commandArgs(trailingOnly = TRUE)
-        cmd.args = cmd.args [seq.int(from = 1, length.out = length(cmd.args) - length(cmd.args.trailing))]
+        cmd.args = cmd.args[seq.int(from = 1, length.out = length(cmd.args) - length(cmd.args.trailing))]
         res = gsub("^(?:--file=(.*)|.*)$", "\\1", cmd.args)
 
         # If multiple --file arguments are given, R uses the last one

--- a/tests/ref_files/pq_example/code/Dockerfile
+++ b/tests/ref_files/pq_example/code/Dockerfile
@@ -27,10 +27,10 @@ LABEL maintainer="author_name <author_email>"
 
 # Install system dependencies
 # If running on Debian and anaconda/miniconda image, use apt-get:
-RUN apt-get update && apt-get upgrade -qy --no-install-recommends apt-utils \
+RUN apt-get update && apt-get upgrade -qy apt-utils \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get install -qy --no-install-recommends gcc \
+RUN apt-get install -qy gcc \
     g++ \
     tzdata \
     wget \
@@ -42,7 +42,7 @@ RUN apt-get install -qy --no-install-recommends gcc \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Get plotting libraries:
-RUN apt-get install -qy --no-install-recommends \
+RUN apt-get install -qy \
             inkscape \
             graphviz \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -81,9 +81,9 @@ RUN conda install python=3.6 \
     && conda install -y r
 
 # Install python packages:
-RUN pip install --no-cache-dir --upgrade pip numpy setuptools \
-    && pip install --no-cache-dir cython \
-    && pip install --no-cache-dir pandas \
+RUN pip install --upgrade pip numpy setuptools \
+    && pip install cython \
+    && pip install pandas \
     && pip list
 
 # Install project specific packages:
@@ -117,7 +117,7 @@ RUN conda install -y r-docopt=0.4.5 r-data.table=1.10.4 r-ggplot2=2.2.1 ; \
 # Install package of interest
 ##############################
 
-RUN pip install --no-cache-dir git+git://github.com/EpiCompBio/stats_utils.git
+RUN pip install git+git://github.com/EpiCompBio/stats_utils.git
 
 ############################
 # Default action to start in

--- a/tests/ref_files/pq_example/code/pq_example/pq_example.R
+++ b/tests/ref_files/pq_example/code/pq_example/pq_example.R
@@ -184,12 +184,12 @@ head(input_data[, eval(var3)])
 nrow(input_data)
 length(which(complete.cases(input_data) == TRUE))
 summary(input_data)
-summary(input_data[, 2:3])
+summary(input_data[, c(2:3)])
 
 # Get the mean for one var specified above:
 input_data[, .(mean = mean(eval(var3), na.rm = TRUE))] # drop with and put column name, usually better practice
 # Get the mean for all columns except the first one in data.table:
-input_data[, lapply(.SD, mean), .SDcols = 2:ncol(input_data)]
+input_data[, lapply(.SD, mean), .SDcols = c(2:ncol(input_data))]
 # Specify columns to get some summary stats (numeric variables):
 colnames(input_data)
 cols_summary <- c(3, 5, 6)

--- a/tests/ref_files/pq_example/code/pq_example/pq_example.py
+++ b/tests/ref_files/pq_example/code/pq_example/pq_example.py
@@ -206,13 +206,13 @@ class SuperHero:
     SuperSaves = 0
 
     def __init__(self, name, power, saves):
-        self.name = name
-        self.power = power
-        self.saves = saves
-        SuperHero.SuperSaves += saves
+       self.name = name
+       self.power = power
+       self.saves = saves
+       SuperHero.SuperSaves += saves
 
     def displaySaves(self):
-        print("Total SuperHero saves %d" % SuperHero.SuperSaves)
+      print("Total SuperHero saves %d" % SuperHero.SuperSaves)
 
     def displaySuperHero(self):
         print("Name:", self.name, "Power:", self.power, "Saves:", self.saves)
@@ -222,7 +222,7 @@ def runOOPHeroes(saves):
     # First object in class:
     super1 = SuperHero("SuperWoman", 'Strong', saves)
     # Second object in class:
-    super2 = SuperHero("AveJoe", 'Common Sense', saves = (saves - 2))
+    super2 = SuperHero("AveJoe", 'Common Sense', saves=(saves - 2))
 
     # Check the Attributes:
     super1.displaySuperHero()

--- a/tests/test_project_quickstart.py
+++ b/tests/test_project_quickstart.py
@@ -68,7 +68,7 @@ cli_options = [
     lambda: create_python_script('{}'.format(test_name)),
     lambda: create_r_script('{}'.format(test_name)),
     lambda: create_pipeline('{}'.format(test_name)),
-    lambda: create_example,
+    lambda: create_example(),
 ]
 
 dirs = ['{}'.format(test_name),
@@ -133,7 +133,6 @@ def dir_trees(workspace):
 
 # Collect and compare for each dir from ref and test, this will include files
 # created with '--script-' options and files with tree dirs:
-@pytest.mark.skip(reason="Known issue: pipeline template files missing during CI")
 def test_collect_and_compare_all_files(run_cmds, dir_trees, workspace):
     '''
     Run project_quickstart commands and files with directory tree for this test and


### PR DESCRIPTION
## Summary
- fix CLI helper functions to pass arguments without '='
- run example creation during tests
- update R template whitespace
- regenerate reference files to match templates
- remove skip for tests

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ad737651c83268598d78491a48a9f