### PR TITLE
Fix codefactor lint on constant c()

### DIFF
--- a/templates/examples/plot_pq_example_mtcars.R
+++ b/templates/examples/plot_pq_example_mtcars.R
@@ -241,7 +241,7 @@ dev.off()
 # object_sizes <- sapply(ls(), function(x) object.size(get(x)))
 # as.matrix(rev(sort(object_sizes))[1:10])
 #rm(list=ls(xxx))
-#objects_to_save <- (c('xxx_var'))
+#objects_to_save <- 'xxx_var'
 #save(list=objects_to_save, file=R_session_saved_image, compress='gzip')
 
 # Filename to save current R session, data and objects at the end:

--- a/templates/examples/plot_pq_example_pandas.R
+++ b/templates/examples/plot_pq_example_pandas.R
@@ -255,7 +255,7 @@ dev.off()
 # object_sizes <- sapply(ls(), function(x) object.size(get(x)))
 # as.matrix(rev(sort(object_sizes))[1:10])
 #rm(list=ls(xxx))
-#objects_to_save <- (c('xxx_var'))
+#objects_to_save <- 'xxx_var'
 #save(list=objects_to_save, file=R_session_saved_image, compress='gzip')
 
 # Filename to save current R session, data and objects at the end:

--- a/templates/examples/pq_example.R
+++ b/templates/examples/pq_example.R
@@ -292,7 +292,7 @@ stargazer(out = sprintf('%s_lm_table.tex', input_name),
 # object_sizes <- sapply(ls(), function(x) object.size(get(x)))
 # as.matrix(rev(sort(object_sizes))[1:10])
 #rm(list=ls(xxx))
-#objects_to_save <- (c('xxx_var'))
+#objects_to_save <- 'xxx_var'
 #save(list=objects_to_save, file=R_session_saved_image, compress='gzip')
 
 # Filename to save current R session, data and objects at the end:

--- a/templates/examples/pq_example_mtcars.R
+++ b/templates/examples/pq_example_mtcars.R
@@ -170,7 +170,7 @@ stargazer(out = sprintf('%s_lm_table.tex', input_name),
 # object_sizes <- sapply(ls(), function(x) object.size(get(x)))
 # as.matrix(rev(sort(object_sizes))[1:10])
 #rm(list=ls(xxx))
-#objects_to_save <- (c('xxx_var'))
+#objects_to_save <- 'xxx_var'
 #save(list=objects_to_save, file=R_session_saved_image, compress='gzip')
 
 # Filename to save current R session, data and objects at the end:

--- a/templates/script_templates/template.R
+++ b/templates/script_templates/template.R
@@ -410,7 +410,7 @@ dev.off()
 # object_sizes <- sapply(ls(), function(x) object.size(get(x)))
 # as.matrix(rev(sort(object_sizes))[1:10])
 #rm(list=ls(xxx))
-#objects_to_save <- (c('xxx_var'))
+#objects_to_save <- 'xxx_var'
 #save(list=objects_to_save, file=R_session_saved_image, compress='gzip')
 
 # Filename to save current R session, data and objects at the end:

--- a/templates/script_templates/template_clean.R
+++ b/templates/script_templates/template_clean.R
@@ -216,7 +216,7 @@ fwrite(object_x, output_file_name,
 # object_sizes <- sapply(ls(), function(x) object.size(get(x)))
 # as.matrix(rev(sort(object_sizes))[1:10])
 #rm(list=ls(xxx))
-#objects_to_save <- (c('xxx_var'))
+#objects_to_save <- 'xxx_var'
 #save(list=objects_to_save, file=R_session_saved_image, compress='gzip')
 
 # Filename to save current R session, data and objects at the end:

--- a/tests/ref_files/pq_example/code/pq_example/plot_pq_example_mtcars.R
+++ b/tests/ref_files/pq_example/code/pq_example/plot_pq_example_mtcars.R
@@ -241,7 +241,7 @@ dev.off()
 # object_sizes <- sapply(ls(), function(x) object.size(get(x)))
 # as.matrix(rev(sort(object_sizes))[1:10])
 #rm(list=ls(xxx))
-#objects_to_save <- (c('xxx_var'))
+#objects_to_save <- 'xxx_var'
 #save(list=objects_to_save, file=R_session_saved_image, compress='gzip')
 
 # Filename to save current R session, data and objects at the end:

--- a/tests/ref_files/pq_example/code/pq_example/plot_pq_example_pandas.R
+++ b/tests/ref_files/pq_example/code/pq_example/plot_pq_example_pandas.R
@@ -255,7 +255,7 @@ dev.off()
 # object_sizes <- sapply(ls(), function(x) object.size(get(x)))
 # as.matrix(rev(sort(object_sizes))[1:10])
 #rm(list=ls(xxx))
-#objects_to_save <- (c('xxx_var'))
+#objects_to_save <- 'xxx_var'
 #save(list=objects_to_save, file=R_session_saved_image, compress='gzip')
 
 # Filename to save current R session, data and objects at the end:

--- a/tests/ref_files/pq_example/code/pq_example/pq_example.R
+++ b/tests/ref_files/pq_example/code/pq_example/pq_example.R
@@ -292,7 +292,7 @@ stargazer(out = sprintf('%s_lm_table.tex', input_name),
 # object_sizes <- sapply(ls(), function(x) object.size(get(x)))
 # as.matrix(rev(sort(object_sizes))[1:10])
 #rm(list=ls(xxx))
-#objects_to_save <- (c('xxx_var'))
+#objects_to_save <- 'xxx_var'
 #save(list=objects_to_save, file=R_session_saved_image, compress='gzip')
 
 # Filename to save current R session, data and objects at the end:

--- a/tests/ref_files/pq_example/code/pq_example/pq_example_mtcars.R
+++ b/tests/ref_files/pq_example/code/pq_example/pq_example_mtcars.R
@@ -170,7 +170,7 @@ stargazer(out = sprintf('%s_lm_table.tex', input_name),
 # object_sizes <- sapply(ls(), function(x) object.size(get(x)))
 # as.matrix(rev(sort(object_sizes))[1:10])
 #rm(list=ls(xxx))
-#objects_to_save <- (c('xxx_var'))
+#objects_to_save <- 'xxx_var'
 #save(list=objects_to_save, file=R_session_saved_image, compress='gzip')
 
 # Filename to save current R session, data and objects at the end:

--- a/tests/ref_files/pq_test_ref.R
+++ b/tests/ref_files/pq_test_ref.R
@@ -410,7 +410,7 @@ dev.off()
 # object_sizes <- sapply(ls(), function(x) object.size(get(x)))
 # as.matrix(rev(sort(object_sizes))[1:10])
 #rm(list=ls(xxx))
-#objects_to_save <- (c('xxx_var'))
+#objects_to_save <- 'xxx_var'
 #save(list=objects_to_save, file=R_session_saved_image, compress='gzip')
 
 # Filename to save current R session, data and objects at the end:

--- a/tests/ref_files/pq_test_ref/code/pq_test_ref/pq_test_ref.R
+++ b/tests/ref_files/pq_test_ref/code/pq_test_ref/pq_test_ref.R
@@ -410,7 +410,7 @@ dev.off()
 # object_sizes <- sapply(ls(), function(x) object.size(get(x)))
 # as.matrix(rev(sort(object_sizes))[1:10])
 #rm(list=ls(xxx))
-#objects_to_save <- (c('xxx_var'))
+#objects_to_save <- 'xxx_var'
 #save(list=objects_to_save, file=R_session_saved_image, compress='gzip')
 
 # Filename to save current R session, data and objects at the end:

--- a/tests/ref_files/pq_test_ref/code/pq_test_ref/pq_test_ref_clean.R
+++ b/tests/ref_files/pq_test_ref/code/pq_test_ref/pq_test_ref_clean.R
@@ -216,7 +216,7 @@ fwrite(object_x, output_file_name,
 # object_sizes <- sapply(ls(), function(x) object.size(get(x)))
 # as.matrix(rev(sort(object_sizes))[1:10])
 #rm(list=ls(xxx))
-#objects_to_save <- (c('xxx_var'))
+#objects_to_save <- 'xxx_var'
 #save(list=objects_to_save, file=R_session_saved_image, compress='gzip')
 
 # Filename to save current R session, data and objects at the end:


### PR DESCRIPTION
## Summary
- clean up R scripts by removing unnecessary `c()` calls around single strings

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bab5905a48326b72e44fb069ddb87