### PR TITLE
Fix CodeFactor lint for R example

### DIFF
--- a/templates/examples/pq_example.R
+++ b/templates/examples/pq_example.R
@@ -184,12 +184,12 @@ head(input_data[, eval(var3)])
 nrow(input_data)
 length(which(complete.cases(input_data) == TRUE))
 summary(input_data)
-summary(input_data[, c(2:3)])
+summary(input_data[, 2:3])
 
 # Get the mean for one var specified above:
 input_data[, .(mean = mean(eval(var3), na.rm = TRUE))] # drop with and put column name, usually better practice
 # Get the mean for all columns except the first one in data.table:
-input_data[, lapply(.SD, mean), .SDcols = c(2:ncol(input_data))]
+input_data[, lapply(.SD, mean), .SDcols = 2:ncol(input_data)]
 # Specify columns to get some summary stats (numeric variables):
 colnames(input_data)
 cols_summary <- c(3, 5, 6)

--- a/tests/ref_files/pq_example/code/pq_example/pq_example.R
+++ b/tests/ref_files/pq_example/code/pq_example/pq_example.R
@@ -184,12 +184,12 @@ head(input_data[, eval(var3)])
 nrow(input_data)
 length(which(complete.cases(input_data) == TRUE))
 summary(input_data)
-summary(input_data[, c(2:3)])
+summary(input_data[, 2:3])
 
 # Get the mean for one var specified above:
 input_data[, .(mean = mean(eval(var3), na.rm = TRUE))] # drop with and put column name, usually better practice
 # Get the mean for all columns except the first one in data.table:
-input_data[, lapply(.SD, mean), .SDcols = c(2:ncol(input_data))]
+input_data[, lapply(.SD, mean), .SDcols = 2:ncol(input_data)]
 # Specify columns to get some summary stats (numeric variables):
 colnames(input_data)
 cols_summary <- c(3, 5, 6)


### PR DESCRIPTION
## Summary
- remove redundant `c()` around slice indices

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688baecc1f788326a9c6dfbbcaa59cb4